### PR TITLE
feat: expose join time of participant and their role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -250,6 +250,15 @@ export interface Participant {
    */
   isSpeaking: boolean
   /**
+   * The timestamp that the participant joined the room.
+   */
+  joinedAt: Date
+  /**
+   * The permission role of the participant.
+   * https://www.api.stream/docs/api/auth/#permission-roles
+   */
+  role: LiveApiModel.Role
+  /**
    * Array of {@link Track} IDs belonging to the Participant.
    */
   trackIds: string[]

--- a/src/core/webrtc/simple-room.ts
+++ b/src/core/webrtc/simple-room.ts
@@ -70,6 +70,8 @@ export const getRoom = (id: string) => {
         isSelf: x === localParticipant,
         connectionQuality: x.connectionQuality,
         displayName: x.name,
+        joinedAt: x.joinedAt,
+        role: JSON.parse(x.metadata).participantRole,
         trackIds: tracks
           .filter((p) => p.participant.sid === x.sid)
           .map((x) => x.trackSid),


### PR DESCRIPTION
Surfaces the join time and the role of each participant in the room.

Using this as part of chat to identify a "primary" host, using a combination of the earliest `joinedAt` where `role=ROLE_HOST`