### PR TITLE
Outset layered children by 1px

### DIFF
--- a/src/core/layouts/index.ts
+++ b/src/core/layouts/index.ts
@@ -426,11 +426,8 @@ export const Layered = {
           html.node`<div data-node-id=${x.id} .data=${{
             zIndex: i + 1,
           }} style=${{
-            width: '100%',
-            height: '100%',
             position: 'absolute',
-            top: 0,
-            left: 0,
+            inset: `${-i}px`,
           }}></div>`,
       )}
     </div>`


### PR DESCRIPTION
A subpixel rendering issue in Chromium causes lower z-index layers to show from behind a layer in front of it even if they occupy the same bounding rectangle. 

This update forces each node in a Layered layout to extend 1px beyond the bounds of node behind it. This ensures the background isn't visible around full-screen content (e.g. screenshare presentation), and a full-screen content isn't visible around around a foreground video.