### PR TITLE
fix: remove prefix v from renderer build command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "1.1.57",
+  "version": "1.1.59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "1.1.57",
+      "version": "1.1.59",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,
@@ -44,13 +44,13 @@
     "add-license": "npx license-check-and-add add -f build/license-header.json",
     "build": "npm run add-license && tsc -p ./tsconfig.json --declaration --skipLibCheck --emitDeclarationOnly --jsx react --esModuleInterop --outDir types && vite build",
     "publish-docs": "npm-run-all --parallel publish-docs:sdk publish-docs:renderer publish-docs:docs publish-docs:demo",
-    "publish-docs:demo": "cd examples/studio-kit-demo && npm install && vite build --emptyOutDir --outDir ../../docs/example/v$npm_package_version --base=/studiokit/example/ && rm -f ../../docs/example/latest && ln -sr ../../docs/example/v$npm_package_version ../../docs/example/latest",
-    "publish-docs:renderer": "cd ./renderer && npm install && vite --config ./renderer.vite.config.ts build --emptyOutDir --outDir ./docs/renderer/v$npm_package_version --base=/studiokit/renderer/v$npm_package_version/ && rm -f ../docs/renderer/latest && ln -sr ../docs/renderer/v$npm_package_version ../docs/renderer/latest",
-    "publish-docs:sdk": "tsc -p ./tsconfig.json --declaration --skipLibCheck --emitDeclarationOnly --jsx react --esModuleInterop --outDir types && vite build --emptyOutDir --outDir ./docs/sdk/v$npm_package_version && rm -f ./docs/sdk/latest && ln -sr ./docs/sdk/v$npm_package_version ./docs/sdk/latest",
-    "publish-docs:docs": "typedoc --options ./typedoc.json --out ./docs/docs/v$npm_package_version && rm -f ./docs/docs/latest && ln -sr ./docs/docs/v$npm_package_version ./docs/docs/latest",
+    "publish-docs:demo": "cd examples/studio-kit-demo && npm install && vite build --emptyOutDir --outDir ../../docs/example/$npm_package_version --base=/studiokit/example/ && rm -f ../../docs/example/latest && ln -sr ../../docs/example/$npm_package_version ../../docs/example/latest",
+    "publish-docs:renderer": "cd ./renderer && npm install && vite --config ./renderer.vite.config.ts build --emptyOutDir --outDir ./docs/renderer/$npm_package_version --base=/studiokit/renderer/$npm_package_version/ && rm -f ../docs/renderer/latest && ln -sr ../docs/renderer/$npm_package_version ../docs/renderer/latest",
+    "publish-docs:sdk": "tsc -p ./tsconfig.json --declaration --skipLibCheck --emitDeclarationOnly --jsx react --esModuleInterop --outDir types && vite build --emptyOutDir --outDir ./docs/sdk/$npm_package_version && rm -f ./docs/sdk/latest && ln -sr ./docs/sdk/$npm_package_version ./docs/sdk/latest",
+    "publish-docs:docs": "typedoc --options ./typedoc.json --out ./docs/docs/$npm_package_version && rm -f ./docs/docs/latest && ln -sr ./docs/docs/$npm_package_version ./docs/docs/latest",
     "watch": "concurrently --kill-others \"vite build --watch\" \"tsc-watch -p ./tsconfig.json --declaration --skipLibCheck --emitDeclarationOnly --jsx react --esModuleInterop --outDir types\"",
     "watch:types": "tsc-watch -p ./tsconfig.json --declaration --skipLibCheck --emitDeclarationOnly --jsx react --esModuleInterop --outDir types",
-    "build:renderer": "cd ./renderer && npm install && vite --config ./renderer.vite.config.ts build --emptyOutDir --outDir ./renderer/dist/ --base=/studiokit/renderer/v$npm_package_version/"
+    "build:renderer": "cd ./renderer && npm install && vite --config ./renderer.vite.config.ts build --emptyOutDir --outDir ./renderer/dist/ --base=/studiokit/renderer/$npm_package_version/"
   },
   "dependencies": {
     "@api.stream/livekit-server-sdk": "^0.5.7",


### PR DESCRIPTION
The previous changes on studio-kit made renderer look up resources on `/$npm_package_version` path instead of `/v$npm_packge_version` path