### PR TITLE
Remove font-size from banner containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -951,7 +951,6 @@ const themes = {
         font-style: normal !important;
         font-weight: 700 !important;
         line-height: 120% !important;
-        font-size: ${scale(36)};
         position: relative;
         z-index: 2;
       }


### PR DESCRIPTION
Recently this line was "fixed" by adding a semicolon, which enabled a legacy font-size control.

All banners have individual size control that are being over-written by this static font size.