### PR TITLE
fix: update renderer version

### DIFF
--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -617,20 +617,6 @@ export const startBroadcast = async (payload: { projectId?: string }) => {
   const { projectId = state.activeProjectId } = payload
   const project = getProject(projectId)
 
-  if (project.videoApi.project.composition.studioSdk.version !== CoreContext.rendererVersion) {
-    await CoreContext.clients.LiveApi().project.updateProject({
-      composition: {
-        studioSdk: {
-          // hint: we're passing rendererUrl to ensure older projects function the same. A change
-          // was made where the live api doesn't store our internal renderer on this model.
-          rendererUrl: undefined,
-          version: CoreContext.rendererVersion,
-        }
-      },
-      updateMask: ['composition.studioSdk.version', 'composition.studioSdk.rendererUrl'],
-    })
-  }
-
   await CoreContext.clients.LiveApi().project.startProjectBroadcast({
     collectionId: project.videoApi.project.collectionId,
     projectId: project.videoApi.project.projectId,


### PR DESCRIPTION
This contains a fix for an issue caused by my last PR: https://github.com/golightstream/api.stream-studio-kit/pull/14

Spotted this while testing - since Joby Studio doesn't use the studio-kit method to start a broadcast, the sdk version is never updated. this means:
- Projects created before this release will forever be on "latest"
- Projects created after that release will forever render at that specific version.

We currently have a call to update the project on load, so I added some extra logic to update the SDK version (limited to hosts/cohosts). I've tested this with the demo app briefly. 