### PR TITLE
fix: fix full-size custom overlays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "1.1.61",
+  "version": "1.1.62",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/transforms/Image2.tsx
+++ b/src/core/transforms/Image2.tsx
@@ -42,7 +42,7 @@ export const Image2 = {
           duration={400}
         >
           <div
-            style={{ opacity: startAnimation ? 1 : 0 }}
+            style={{ opacity: startAnimation ? 1 : 0, width: '100%', height: '100%' }}
             className={`image-transition`}
           >
             {src && (

--- a/src/core/transforms/Logo.tsx
+++ b/src/core/transforms/Logo.tsx
@@ -54,7 +54,7 @@ export const Logo = {
           duration={400}
         >
           <div
-            style={{ opacity: startAnimation ? 1 : 0 }}
+            style={{ opacity: startAnimation ? 1 : 0, width: '100%', height: '100%' }}
             className={`logo-transition`}
           >
             {src && (

--- a/src/core/transforms/Overlay.tsx
+++ b/src/core/transforms/Overlay.tsx
@@ -80,7 +80,7 @@ export const Overlay = {
           duration={400}
         >
           <div
-            style={{ opacity: startAnimation ? 1 : 0 }}
+            style={{ opacity: startAnimation ? 1 : 0, width: '100%', height: '100%' }}
             className={`image-transition`}
           >
             {meta?.type === 'html-overlay' && (

--- a/src/core/transforms/Video2.tsx
+++ b/src/core/transforms/Video2.tsx
@@ -177,7 +177,7 @@ export const Video2 = {
           duration={400}
         >
           <div
-            style={{ opacity: startAnimation ? 1 : 0 }}
+            style={{ opacity: startAnimation ? 1 : 0, width: '100%', height: '100%' }}
             className={`video-transition`}
           >
             {src && (


### PR DESCRIPTION
This element's parent has a `width` and `height` of `100%`, and the child (e.g. custom overlays) can potentially be the same. So, this needs to be the same as the parent for the child to be sized correctly.