### PR TITLE
fix: mediaStreamTrack was not being updated when a track was enabled or disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/renderer/renderer-main.ts
+++ b/renderer/renderer-main.ts
@@ -30,7 +30,7 @@ const run = async () => {
   await project.joinRoom()
 
   sdk.render({
-    containerEl: document.getElementById('root'),
+    containerEl: document.getElementById('root') as HTMLElement,
     projectId: project.id,
     dragAndDrop: false,
   })

--- a/src/core/sources/WebRTC.ts
+++ b/src/core/sources/WebRTC.ts
@@ -11,7 +11,7 @@ type SourceDeclaration = Compositor.Source.SourceDeclaration
 export type RoomParticipantSource = {
   // Equivalent to room participantId
   id: string
-  value: MediaStream | MediaStreamTrack
+  value: MediaStream
   props: {
     // Equivalent to room participantId
     id: string
@@ -31,7 +31,7 @@ export type RoomParticipantSource = {
     participantId: string
 
     trackId: string
-    
+
     microphone?: SDK.Track
   }
 }
@@ -45,7 +45,13 @@ export const RoomParticipant = {
     videoEnabled: {},
     audioEnabled: {},
   },
-  init({ addSource, removeSource, updateSource, getSource }) {
+  init({
+    addSource,
+    removeSource,
+    updateSource,
+    getSource,
+    modifySourceValue,
+  }) {
     CoreContext.on('RoomJoined', ({ room }) => {
       let listeners = {} as { [id: string]: Function }
       let previousTracks = [] as SDK.Track[]
@@ -60,6 +66,7 @@ export const RoomParticipant = {
           .filter((p) => p?.type === 'camera' && p?.isExternal === true)
           .forEach((track) => {
             if (track.type === 'camera') {
+              const srcObject = participantStreams[track.id]
               const participant = room.getParticipant(track.participantId)
               const webcamTrack = room.getTrack(track.id)
               const source = getSource(track?.id)
@@ -67,6 +74,12 @@ export const RoomParticipant = {
                 const microphoneTrack = room.getTrack(
                   participant?.meta[track.id]?.microphone,
                 )
+                // Replace the tracks on the existing MediaStream
+                updateMediaStreamTracks(srcObject, {
+                  video: webcamTrack?.mediaStreamTrack,
+                  audio: microphoneTrack?.mediaStreamTrack,
+                })
+
                 updateSource(track.id, {
                   videoEnabled: Boolean(webcamTrack && !webcamTrack.isMuted),
                   audioEnabled: Boolean(
@@ -114,7 +127,7 @@ export const RoomParticipant = {
           updateMediaStreamTracks(srcObjectScreenshare, {
             video: screenshareTrack?.mediaStreamTrack,
           })
-          
+
           updateSource(x.id, {
             videoEnabled: Boolean(webcamTrack && !webcamTrack.isMuted),
             audioEnabled: Boolean(microphoneTrack && !microphoneTrack.isMuted),
@@ -147,14 +160,14 @@ export const RoomParticipant = {
         previousTracks = tracks.filter((t) => Boolean(t?.mediaStreamTrack))
 
         newTracks.forEach((x) => {
-          const { mediaStreamTrack, id, participantId, type } = room.getTrack(
-            x.id,
-          )
+          const srcObject = new MediaStream([])
+          participantStreams[x.id] = srcObject
+          const { id, participantId, type } = room.getTrack(x.id)
 
           const source = {
             id,
             isActive: true,
-            value: mediaStreamTrack,
+            value: srcObject,
             props: {
               id,
               trackId: id,
@@ -165,13 +178,7 @@ export const RoomParticipant = {
           } as Compositor.Source.NewSource
 
           // Add each new track as a source
-          if (mediaStreamTrack) {
-            if (mediaStreamTrack.kind === 'video') {
-              addSource(source)
-            } else {
-              addSource(source)
-            }
-          }
+          addSource(source)
         })
 
         // Dispose of the old tracks
@@ -179,7 +186,6 @@ export const RoomParticipant = {
           removeSource(x.id)
           listeners[x.id]?.()
         })
-
         updateParticipants()
       })
 

--- a/src/core/sources/WebRTC.ts
+++ b/src/core/sources/WebRTC.ts
@@ -50,7 +50,6 @@ export const RoomParticipant = {
     removeSource,
     updateSource,
     getSource,
-    modifySourceValue,
   }) {
     CoreContext.on('RoomJoined', ({ room }) => {
       let listeners = {} as { [id: string]: Function }

--- a/src/core/sources/WebRTC.ts
+++ b/src/core/sources/WebRTC.ts
@@ -149,7 +149,9 @@ export const RoomParticipant = {
       room.useTracks((tracks) => {
         // Get tracks not contained in previousTracks
         const newTracks = tracks.filter(
-          (track) => !previousTracks.some((x) => x.id === track.id),
+          (track) =>
+            !previousTracks.some((x) => x.id === track.id) &&
+            Boolean(track?.mediaStreamTrack),
         )
         // Get previous tracks not contained in current tracks
         const removedTracks = previousTracks.filter(
@@ -162,23 +164,25 @@ export const RoomParticipant = {
         newTracks.forEach((x) => {
           const srcObject = new MediaStream([])
           participantStreams[x.id] = srcObject
-          const { id, participantId, type } = room.getTrack(x.id)
-
-          const source = {
-            id,
-            isActive: true,
-            value: srcObject,
-            props: {
-              id,
-              trackId: id,
-              participantId,
-              isMuted: x.isMuted,
-              type,
-            },
-          } as Compositor.Source.NewSource
+          const { id, participantId, type, mediaStreamTrack } = room.getTrack(
+            x.id,
+          )
 
           // Add each new track as a source
-          addSource(source)
+          if (mediaStreamTrack) {
+            addSource({
+              id,
+              isActive: true,
+              value: srcObject,
+              props: {
+                id,
+                trackId: id,
+                participantId,
+                isMuted: x.isMuted,
+                type,
+              },
+            } as Compositor.Source.NewSource)
+          }
         })
 
         // Dispose of the old tracks

--- a/src/core/transforms/WebRTC.tsx
+++ b/src/core/transforms/WebRTC.tsx
@@ -106,7 +106,6 @@ export const RoomParticipant = {
 
       useEffect(() => {
         if (!props && ref.current) {
-          // mediaSource = null
           ref.current.srcObject = null
           ref.current = null
         }

--- a/src/core/transforms/WebRTC.tsx
+++ b/src/core/transforms/WebRTC.tsx
@@ -3,14 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * -------------------------------------------------------------------------------------------- */
 import ReactDOM from 'react-dom'
-import React, { useLayoutEffect, useState } from 'react'
+import React, { useLayoutEffect, useState, useEffect, useRef } from 'react'
 import { isMatch } from 'lodash-es'
-import { useEffect, useRef } from 'react'
 import { CoreContext } from '../context'
 import { Compositor } from '../namespaces'
 import { RoomParticipantSource } from '../sources'
 import { getProject, getProjectRoom } from '../data'
-import { updateMediaStreamTracks } from '../../helpers/webrtc'
 
 type Props = {
   volume: number
@@ -49,7 +47,6 @@ export const RoomParticipant = {
 
     let source: any
     let props = initialProps
-    let mediaSource = new MediaStream([])
 
     const getSize = (
       width: number,
@@ -78,7 +75,7 @@ export const RoomParticipant = {
 
       const { volume = 1, isHidden = false } = props || {}
       const [labelSize, setLabelSize] = useState<0 | 1 | 2 | 3>(0)
-      
+
       /* It's checking if the participant is the local participant. */
       const isSelf =
         source?.id === room?.participantId ||
@@ -100,34 +97,20 @@ export const RoomParticipant = {
           })
         })
 
-        /*  It's a hack to get around the fact that we're using a MediaStreamTrack as a source,
-            but the video element requires a MediaStream. */
-        if (source?.value instanceof MediaStreamTrack) {
-          if (mediaSource) {
-            updateMediaStreamTracks(mediaSource, {
-              video: source?.value,
-              audio: source?.props?.microphone?.mediaStreamTrack,
-            })
-          }
-        } else {
-          mediaSource = source?.value
-        }
-
-        if (mediaSource && mediaSource !== ref.current.srcObject) {
-          ref.current.srcObject = mediaSource
+        if (source?.value && source?.value !== ref.current.srcObject) {
+          ref.current.srcObject = source?.value
         } else if (!source?.value) {
           ref.current.srcObject = null
         }
-      }, [ref.current, source?.value, source?.props?.microphone])
+      }, [ref.current, source?.value])
 
       useEffect(() => {
         if (!props && ref.current) {
-          mediaSource = null
+          // mediaSource = null
           ref.current.srcObject = null
           ref.current = null
         }
       }, [props])
-
 
       useLayoutEffect(() => {
         if (!ref.current) return

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -42,8 +42,6 @@ export const defaultStyles = {
     width: '100%',
   },
   logo: {
-    width: '100%',
-    height: '100%',
     objectFit: 'contain',
     position: 'unset',
   },


### PR DESCRIPTION
This has led to issues where the track's state was not being accurately reflected on showcase, causing confusion and errors.
[sc-19026]