### PR TITLE
When sending data via livekit, use optional chaining to only send to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/webrtc/simple-room.ts
+++ b/src/core/webrtc/simple-room.ts
@@ -477,9 +477,9 @@ export const getRoom = (id: string) => {
     },
     sendData: (data, recipientIds) => {
       const encoded = encoder.encode(JSON.stringify(data))
-      const participants = recipientIds?.map(
-        (x) => room.livekitRoom?.getParticipantByIdentity(x).sid,
-      )
+      const participants = recipientIds
+        ?.map((x) => room.livekitRoom?.getParticipantByIdentity(x)?.sid)
+        .filter(Boolean)
       return localParticipant.publishData(
         encoded,
         DataPacket_Kind.RELIABLE,


### PR DESCRIPTION
…valid participants. This prevents type errors. Bump version to 2.0.7.