### PR TITLE
chore: dynamic renderer version

### DIFF
--- a/.github/workflows/deploy-renderer-without-publish.yml
+++ b/.github/workflows/deploy-renderer-without-publish.yml
@@ -37,5 +37,5 @@ jobs:
           preCommands: |
             npm install
           postCommands: |
-            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }}-test --source ../../renderer/dist --destination renderer.json
+            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }}-test --source ../../renderer/dist --destination renderer.json --sdkversion=${{ steps.package-version.outputs.current-version }}-test
             wrangler kv:bulk put renderer.json --binding=SCENELESS_KV 

--- a/.github/workflows/deploy-renderer.yml
+++ b/.github/workflows/deploy-renderer.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: cloudflare/wrangler-action@2.0.0
         name: Publish Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        # if: startsWith(github.ref, 'refs/tags/v')
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
@@ -44,7 +44,7 @@ jobs:
 
       - uses: cloudflare/wrangler-action@2.0.0
         name: Publish latest
-        if: ${{github.ref == 'refs/heads/main' }}
+        # if: ${{github.ref == 'refs/heads/main' }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/deploy-renderer.yml
+++ b/.github/workflows/deploy-renderer.yml
@@ -7,9 +7,9 @@ name: Publish renderer
 on:
   push:
     branches:
-      - main
+      - mahendra/dynamic-renderer-version
     tags:
-    - v3.*
+      - v3.*
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-renderer.yml
+++ b/.github/workflows/deploy-renderer.yml
@@ -39,7 +39,7 @@ jobs:
           preCommands: |
             npm install
           postCommands: |
-            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }} --source ../../renderer/dist --destination renderer.json
+            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }} --source ../../renderer/dist --destination renderer.json --sdkversion=${{ steps.package-version.outputs.current-version }}
             wrangler kv:bulk put renderer.json --binding=SCENELESS_KV 
 
       - uses: cloudflare/wrangler-action@2.0.0
@@ -52,5 +52,5 @@ jobs:
           preCommands: |
             npm install
           postCommands: |
-            node directory-to-kv.js --prefix version/latest-v2 --source ../../renderer/dist --destination renderer.json
+            node directory-to-kv.js --prefix version/latest-v2 --source ../../renderer/dist --destination renderer.json --sdkversion=latest-v2
             wrangler kv:bulk put renderer.json --binding=SCENELESS_KV 

--- a/.github/workflows/deploy-renderer.yml
+++ b/.github/workflows/deploy-renderer.yml
@@ -7,7 +7,7 @@ name: Publish renderer
 on:
   push:
     branches:
-      - mahendra/dynamic-renderer-version
+      - main
     tags:
       - v3.*
 
@@ -31,7 +31,7 @@ jobs:
 
       - uses: cloudflare/wrangler-action@2.0.0
         name: Publish Release
-        # if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
@@ -39,12 +39,12 @@ jobs:
           preCommands: |
             npm install
           postCommands: |
-            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }} --source ../../renderer/dist --destination renderer.json --sdkversion=${{ steps.package-version.outputs.current-version }}
+            node directory-to-kv.js --prefix version/${{ steps.package-version.outputs.current-version }} --source ../../renderer/dist --destination renderer.json
             wrangler kv:bulk put renderer.json --binding=SCENELESS_KV 
 
       - uses: cloudflare/wrangler-action@2.0.0
         name: Publish latest
-        # if: ${{github.ref == 'refs/heads/main' }}
+        if: ${{github.ref == 'refs/heads/main' }}
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
@@ -52,5 +52,5 @@ jobs:
           preCommands: |
             npm install
           postCommands: |
-            node directory-to-kv.js --prefix version/latest-v2 --source ../../renderer/dist --destination renderer.json --sdkversion=latest-v2
+            node directory-to-kv.js --prefix version/latest-v2 --source ../../renderer/dist --destination renderer.json
             wrangler kv:bulk put renderer.json --binding=SCENELESS_KV 

--- a/build/hosted-renderer/directory-to-kv.js
+++ b/build/hosted-renderer/directory-to-kv.js
@@ -27,7 +27,7 @@ try {
 const readFiles = (rootPath, dir = '') => {
   const files = readdirSync(join(rootPath, dir));
   let found = [];
-  
+
   files.forEach((file) => {
     if (statSync(`${rootPath}${dir}/${file}`).isDirectory()) {
       found = found.concat(readFiles(rootPath, `${dir}/${file}`));
@@ -35,7 +35,7 @@ const readFiles = (rootPath, dir = '') => {
       found.push(join(dir, '/', file));
     }
   });
-  
+
   return found;
 };
 
@@ -47,10 +47,17 @@ const files = readFiles(input);
 
 for (const [index, path] of files.entries()) {
   const f = readFileSync(join(input, path));
-  
+
+  const indexHtml = path.includes('index.html')
+    ? isBinary(null, f)
+      ? f.toString('base64')
+      : f.toString()
+        .replace(/\/studiokit\/renderer\/[0-9.]+\//g, `/studiokit/renderer/${argv.sdkversion}/`)
+    : undefined;
+
   append(`${JSON.stringify({
     key: `${argv.prefix}${path}`,
-    value: isBinary(null, f) ? f.toString('base64') : f.toString(),
+    value: indexHtml ?? (isBinary(null, f) ? f.toString('base64') : f.toString()),
     base64: isBinary(null, f),
   })}${index === files.length - 1 ? '' : ','}`);
 }

--- a/build/hosted-renderer/package-lock.json
+++ b/build/hosted-renderer/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "hosted-renderer",
       "version": "1.0.0",
-      "license": "ISC",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@types/node": "^18.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Currently, during the building of the renderer in studio-kit, the build process for the latest-v2 renderer uploads the files to Cloud flare KV, suffixed with "latest-v2". However, the Vite build generates the file with a reference to ${version} (ex 2.1.4). 

This creates a problem if the git build process for renderer-${version} fails. The index file for the latest-v2 renderer ends up referencing files that do not exist on Cloudflare KV.    

The build file for latest-v2 should have references in index.html updated to "latest-v2".

https://xsolla.atlassian.net/browse/LSTREAM-252