### PR TITLE
Hudson/drag behavior cleanup

### DIFF
--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -218,10 +218,6 @@ const ElementTree = (props: { nodeId: string }) => {
         },
         ondragend: (e) => {
           isDragging.current = false
-          if (!foundDropTarget) {
-            log.info('Compositor: No drop target - deleting node', node)
-            CoreContext.Command.deleteNode({ nodeId: node.id })
-          }
           setDraggingNodeId(null)
           wrapperEl.toggleAttribute('data-dragging', true)
           log.debug('Compositor: DragEnd', e)


### PR DESCRIPTION
https://xsolla.atlassian.net/browse/LSTREAM-472

- Improve drag feedback (behavior when dragging)
- Replaced soft gray border with small yellow border to highlight active item
- Change solid yellow border to dashed yellow border to indicate active item is preparing to change
- Reduced opacity of active item (80% -> 60%)
- Changed opacity behavior to only apply when the drop target has changed
- Removed "hover" border indicator once item has entered "drag" state

I believe all of these items together help indicate the change of possible states throughout the lifecycle of a "drag", and the resulting behavior the user can expect when releasing the dragged item.