### PR TITLE
chore: add support for new guest-link apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.24",
+      "version": "3.0.25",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",
-        "@api.stream/sdk": "^1.0.28",
+        "@api.stream/sdk": "^1.0.38",
         "csx": "^10.0.2",
         "fast-deep-equal": "^3.1.3",
         "heresy": "^1.0.4",
@@ -77,9 +77,9 @@
       }
     },
     "node_modules/@api.stream/protocol-event-api": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@api.stream/protocol-event-api/-/protocol-event-api-1.0.2.tgz",
-      "integrity": "sha512-WxYbJ7HcBD39exk7tMz3jiY5necHDmbv1dxmVrMW/zvS+y2xXnpJ+/xGMKHH5wmAANxsXexqMc/14jhL9LohHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@api.stream/protocol-event-api/-/protocol-event-api-1.0.4.tgz",
+      "integrity": "sha512-w2XNpEADemYiXNfGsVOF+5rdk8AKFRpsOZI0jkj42aYZo001muRr0UqWtUseQifgPVKROCCaEy472RhZeYX/bg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.4.4",
         "@protobuf-ts/plugin": "^2.1.0",
@@ -116,12 +116,12 @@
       }
     },
     "node_modules/@api.stream/sdk": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@api.stream/sdk/-/sdk-1.0.28.tgz",
-      "integrity": "sha512-luD6gwYMKQbU/kKM57L8nBAnDdO0OBPqCRR8d/jtrm3zqE4ZSAhzuO6hadZOf9euOnzvk85bxSE95J8p9tAY3w==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@api.stream/sdk/-/sdk-1.0.38.tgz",
+      "integrity": "sha512-eExK2z2vhtpA7hwnotAqRc8LqYIxu6FtVKZZlCj5wb698Rl3DDWpdcTVO3WYqr6YNGRsa4J3ZnTryqNC4AArsQ==",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^0.5.7",
-        "@api.stream/protocol-event-api": "1.0.2",
+        "@api.stream/protocol-event-api": "1.0.4",
         "@api.stream/protocol-layout-api": "1.0.4",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@types/ws": "^8.2.2",
@@ -130,7 +130,7 @@
         "jwt-decode": "^3.1.2",
         "livekit-client": "^0.15.2",
         "matcher": "^4.0.0",
-        "nice-grpc-web": "^1.0.3",
+        "nice-grpc-web": "^3.3.4",
         "rxjs": "^7.5.5",
         "typedoc-plugin-missing-exports": "^0.22.6",
         "typescript-logging": "^2.0.1",
@@ -1032,6 +1032,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz",
       "integrity": "sha512-ERft9/0/8CmYalqOVnJnpdDry28q+j+nAlFFARdjyxXDJ+Mhgv9+F600QC8BR9ygOfrXRlAk6CvST2j+JCpQPg==",
+      "peer": true,
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -1723,12 +1724,9 @@
       }
     },
     "node_modules/abort-controller-x": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.7.tgz",
-      "integrity": "sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==",
-      "dependencies": {
-        "node-abort-controller": "^1.2.1 || ^2.0.0"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1921,7 +1919,8 @@
     "node_modules/browser-headers": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==",
+      "peer": true
     },
     "node_modules/browser-resolve": {
       "version": "2.0.0",
@@ -3856,9 +3855,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4455,24 +4454,30 @@
       }
     },
     "node_modules/nice-grpc-common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-1.1.0.tgz",
-      "integrity": "sha512-klxJ/lxMyH1KkT02woMBWL3A7BQSTH5jGodJIpNbbv7WKeFBWJaEtT6p7kZJBhGYXtSsQ+TyMU1EJR9BH14YfQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.2.tgz",
+      "integrity": "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==",
       "dependencies": {
-        "node-abort-controller": "^2.0.0",
         "ts-error": "^1.0.6"
       }
     },
     "node_modules/nice-grpc-web": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-1.1.0.tgz",
-      "integrity": "sha512-EqSuzDdNS2ABS2Hy7SRfdxZCsRibJtuy6oynn2MRNizKk+hLtI0YPMeJ2kRrOdYS4rsJgdM02nLXyVcYl4grkw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-3.3.4.tgz",
+      "integrity": "sha512-L8UQC/jQ8jAXmPM76On2CDDSDPxIfV8ltXu2anEUKYUdrqMMYZwnUVw3s2fo5p6dotIR6qyVLR9qSXvDOeMmPA==",
       "dependencies": {
-        "@improbable-eng/grpc-web": "^0.15.0",
-        "abort-controller-x": "^0.2.6",
+        "abort-controller-x": "^0.4.0",
+        "isomorphic-ws": "^5.0.0",
         "js-base64": "^3.7.2",
-        "nice-grpc-common": "^1.1.0",
-        "node-abort-controller": "^2.0.0"
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/nice-grpc-web/node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/nice-try": {
@@ -4480,11 +4485,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node_modules/node-abort-controller": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
-      "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
     },
     "node_modules/node-cleanup": {
       "version": "2.1.2",
@@ -6758,9 +6758,9 @@
       }
     },
     "@api.stream/protocol-event-api": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@api.stream/protocol-event-api/-/protocol-event-api-1.0.2.tgz",
-      "integrity": "sha512-WxYbJ7HcBD39exk7tMz3jiY5necHDmbv1dxmVrMW/zvS+y2xXnpJ+/xGMKHH5wmAANxsXexqMc/14jhL9LohHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@api.stream/protocol-event-api/-/protocol-event-api-1.0.4.tgz",
+      "integrity": "sha512-w2XNpEADemYiXNfGsVOF+5rdk8AKFRpsOZI0jkj42aYZo001muRr0UqWtUseQifgPVKROCCaEy472RhZeYX/bg==",
       "requires": {
         "@grpc/grpc-js": "^1.4.4",
         "@protobuf-ts/plugin": "^2.1.0",
@@ -6796,12 +6796,12 @@
       }
     },
     "@api.stream/sdk": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@api.stream/sdk/-/sdk-1.0.28.tgz",
-      "integrity": "sha512-luD6gwYMKQbU/kKM57L8nBAnDdO0OBPqCRR8d/jtrm3zqE4ZSAhzuO6hadZOf9euOnzvk85bxSE95J8p9tAY3w==",
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@api.stream/sdk/-/sdk-1.0.38.tgz",
+      "integrity": "sha512-eExK2z2vhtpA7hwnotAqRc8LqYIxu6FtVKZZlCj5wb698Rl3DDWpdcTVO3WYqr6YNGRsa4J3ZnTryqNC4AArsQ==",
       "requires": {
         "@api.stream/livekit-server-sdk": "^0.5.7",
-        "@api.stream/protocol-event-api": "1.0.2",
+        "@api.stream/protocol-event-api": "1.0.4",
         "@api.stream/protocol-layout-api": "1.0.4",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@types/ws": "^8.2.2",
@@ -6810,7 +6810,7 @@
         "jwt-decode": "^3.1.2",
         "livekit-client": "^0.15.2",
         "matcher": "^4.0.0",
-        "nice-grpc-web": "^1.0.3",
+        "nice-grpc-web": "^3.3.4",
         "rxjs": "^7.5.5",
         "typedoc-plugin-missing-exports": "^0.22.6",
         "typescript-logging": "^2.0.1",
@@ -7381,6 +7381,7 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.15.0.tgz",
       "integrity": "sha512-ERft9/0/8CmYalqOVnJnpdDry28q+j+nAlFFARdjyxXDJ+Mhgv9+F600QC8BR9ygOfrXRlAk6CvST2j+JCpQPg==",
+      "peer": true,
       "requires": {
         "browser-headers": "^0.4.1"
       }
@@ -7897,12 +7898,9 @@
       }
     },
     "abort-controller-x": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.7.tgz",
-      "integrity": "sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==",
-      "requires": {
-        "node-abort-controller": "^1.2.1 || ^2.0.0"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -8056,7 +8054,8 @@
     "browser-headers": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg==",
+      "peer": true
     },
     "browser-resolve": {
       "version": "2.0.0",
@@ -9513,9 +9512,9 @@
       "requires": {}
     },
     "js-base64": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -9996,24 +9995,30 @@
       "dev": true
     },
     "nice-grpc-common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-1.1.0.tgz",
-      "integrity": "sha512-klxJ/lxMyH1KkT02woMBWL3A7BQSTH5jGodJIpNbbv7WKeFBWJaEtT6p7kZJBhGYXtSsQ+TyMU1EJR9BH14YfQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.2.tgz",
+      "integrity": "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==",
       "requires": {
-        "node-abort-controller": "^2.0.0",
         "ts-error": "^1.0.6"
       }
     },
     "nice-grpc-web": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-1.1.0.tgz",
-      "integrity": "sha512-EqSuzDdNS2ABS2Hy7SRfdxZCsRibJtuy6oynn2MRNizKk+hLtI0YPMeJ2kRrOdYS4rsJgdM02nLXyVcYl4grkw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-3.3.4.tgz",
+      "integrity": "sha512-L8UQC/jQ8jAXmPM76On2CDDSDPxIfV8ltXu2anEUKYUdrqMMYZwnUVw3s2fo5p6dotIR6qyVLR9qSXvDOeMmPA==",
       "requires": {
-        "@improbable-eng/grpc-web": "^0.15.0",
-        "abort-controller-x": "^0.2.6",
+        "abort-controller-x": "^0.4.0",
+        "isomorphic-ws": "^5.0.0",
         "js-base64": "^3.7.2",
-        "nice-grpc-common": "^1.1.0",
-        "node-abort-controller": "^2.0.0"
+        "nice-grpc-common": "^2.0.2"
+      },
+      "dependencies": {
+        "isomorphic-ws": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+          "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+          "requires": {}
+        }
       }
     },
     "nice-try": {
@@ -10021,11 +10026,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-abort-controller": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
-      "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
     },
     "node-cleanup": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@api.stream/livekit-server-sdk": "^1.1.3",
-    "@api.stream/sdk": "^1.0.28",
+    "@api.stream/sdk": "^1.0.38",
     "csx": "^10.0.2",
     "fast-deep-equal": "^3.1.3",
     "heresy": "^1.0.4",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -745,7 +745,23 @@ export interface Studio {
    * may distribute to invite guests to their stream
    * (typically as WebRTC {@link Participant Participants}).
    */
+
+  /**
+  * These are a new set of endpoints for managing guest codes and are different to the existing one
+  * To create a guest code, The guest code returned looks like this, linkUrl is what you should copy to the users 
+  */
   createGuestLink: (baseUrl: string, options?: GuestOptions) => Promise<string>
+ 
+  /**
+   * To delete a guest code
+   */
+  deleteGuestLink: (link: string) => Promise<void>
+
+  /**
+   * To list all guest codes
+   */
+  getGuestLinks: (options?: GuestOptions) => Promise<{ guestCodes: LiveApiModel.IssuedGuestCode[] }>
+  
   /**
    * Create a link with an embedded access token.
    * This link resolves to a URL demonstrating the stream output.


### PR DESCRIPTION
This PR integrates three new endpoints from api.stream: getGuestCodes, createGuestCode, and deleteGuestCode. These endpoints allow us to manage guest links for users effectively.