### PR TITLE
Hudson/drag n drop cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.25",
+  "version": "3.0.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.25",
+      "version": "3.0.27",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -256,12 +256,12 @@ const ElementTree = (props: { nodeId: string }) => {
               })
             })
 
-            wrapperEl.removeEventListener('pointermove', onGlobalPointerMove)
-            wrapperEl.removeEventListener('pointerup', onGlobalPointerUp)
+            document.removeEventListener('pointermove', onGlobalPointerMove)
+            document.removeEventListener('pointerup', onGlobalPointerUp)
           }
 
-          wrapperEl.addEventListener('pointermove', onGlobalPointerMove)
-          wrapperEl.addEventListener('pointerup', onGlobalPointerUp)
+          document.addEventListener('pointermove', onGlobalPointerMove)
+          document.addEventListener('pointerup', onGlobalPointerUp)
         },
         onpointerup: (e) => {
           // If a target is draggable, it will also be treated as


### PR DESCRIPTION
Convert drag events to pointer events. This leaves the existing behavior feeling much the same, except we now have control over the cursor iconography. The cursor maintains the same "hand" style throughout the lifecycle of a drag. 

Also, updates the drag preview to disappear when hovering over an eligible drop target.

Gif demonstration:
![chrome_nMF9eWTCTg](https://github.com/user-attachments/assets/bbaf8858-e55e-4efd-ab7f-abe2ff140146)

https://xsolla.atlassian.net/browse/LSTREAM-473