### PR TITLE
Hudson/preset dnd update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.28",
+      "version": "3.0.29",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.28",
+  "version": "3.0.29",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Preset behavior wasn't moved over to pointer events when the rest of drag and drop was.
Addresses the concern raised in testing of this issue:

https://xsolla.atlassian.net/browse/LSTREAM-473