### PR TITLE
chore: enforce the selected deviceId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.30",
+  "version": "3.0.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.30",
+      "version": "3.0.34",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.33",
+  "version": "3.0.34",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/webrtc/simple-room.ts
+++ b/src/core/webrtc/simple-room.ts
@@ -349,7 +349,9 @@ export const getRoom = (id: string) => {
     addCamera: async (options = {}) => {
       const tracks = await localParticipant.createTracks({
         video: {
-          deviceId: options.deviceId,
+          deviceId: {
+            exact: options.deviceId?.toString(),
+          },
           resolution: options.resolution || {
             width: 1280,
             height: 720,


### PR DESCRIPTION
The selected device ID for adding the camera should be enforced, regardless of whether it meets the resolution constraints.

https://xsolla.atlassian.net/browse/LSTREAM-741