### PR TITLE
fix: minor bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.36",
+      "version": "3.0.37",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/transforms/GameSource.tsx
+++ b/src/core/transforms/GameSource.tsx
@@ -27,9 +27,9 @@ const OfflineIcon = () => (
       y2="200"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="40"
@@ -38,9 +38,9 @@ const OfflineIcon = () => (
       y2="200"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="48"
@@ -49,9 +49,9 @@ const OfflineIcon = () => (
       y2="216"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="160"
@@ -60,9 +60,9 @@ const OfflineIcon = () => (
       y2="200"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="160"
@@ -71,9 +71,9 @@ const OfflineIcon = () => (
       y2="115.63"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="200"
@@ -82,9 +82,9 @@ const OfflineIcon = () => (
       y2="159.63"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
     <line
       x1="120"
@@ -93,9 +93,9 @@ const OfflineIcon = () => (
       y2="200"
       fill="none"
       stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="16"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="16"
     />
   </svg>
 )

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -743,7 +743,7 @@ export const commands = (_project: ScenelessProject) => {
       return content.props.layout
     },
     getBanners() {
-      return (getProject(_project.id).props?.banners || []) as Banner[]
+      return (getProject(_project.id)?.props?.banners || []) as Banner[]
     },
     getParticipants() {
       return content.children.concat(audioContainer.children).filter((node) => {
@@ -1267,7 +1267,6 @@ export const commands = (_project: ScenelessProject) => {
 
       const extendedDefaultStyles = {
         ...defaultStyles['alert'],
-        ...(foregroundVideoContainer?.children.length && { opacity: 0 }),
       }
 
       const { x: rootWidth } = root.props.size
@@ -2184,7 +2183,7 @@ export const commands = (_project: ScenelessProject) => {
         })
     },
     getProp(prop) {
-      return getProject(_project.id).props[prop]
+      return getProject(_project.id)?.props[prop]
     },
     setProp(prop, val) {
       return Command.updateProjectProps({


### PR DESCRIPTION
- This check will prevent errors when a project is removed, and someone still attempts to access its props after a Studio account deletion.

- Also, it reverts the code where we set the opacity of the AlertContainer to zero when VideoOverlay is enabled.

https://xsolla.atlassian.net/browse/LSTREAM-775