### PR TITLE
feat: add support for enabling multiple custom overlays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.37",
+  "version": "3.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.37",
+      "version": "3.0.38",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.37",
+  "version": "3.0.38",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/transforms/components/Iframe.tsx
+++ b/src/core/transforms/components/Iframe.tsx
@@ -2,12 +2,11 @@
  * Copyright (c) Infiniscene, Inc. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * -------------------------------------------------------------------------------------------- */
-import { IframeProps } from '../../types'
-import React from 'react'
-import APIKitAnimation from '../../../compositor/html/html-animation'
-import { APIKitAnimationTypes } from '../../../animation/core/types'
+import React, { ComponentType } from 'react'
 
-const Iframe = ({
+import { IframeProps } from '../../types'
+
+const Iframe: ComponentType<IframeProps> = ({
   url,
   allowFullScreen,
   position,
@@ -17,31 +16,58 @@ const Iframe = ({
   overflow,
   styles,
   onLoad,
+  onMouseOver,
+  onMouseOut,
+  scrolling = 'no',
   id,
   frameBorder,
+  ariaHidden,
+  sandbox,
+  allow,
   className,
+  title,
+  ariaLabel,
+  ariaLabelledby,
   name,
   target,
-  iframeRef,
-  children,
+  loading,
+  importance,
+  referrerpolicy,
+  allowpaymentrequest,
   src,
+  key,
+  iframeRef,
 }: IframeProps) => {
   const defaultProps = Object.assign({
     src: src || url,
     target: target || null,
     style: {
       position: position || null,
-      display: display || 'block',
+      display: display || 'initial',
       overflow: overflow || null,
-      ...styles,
     },
+    scrolling: scrolling || null,
+    allowpaymentrequest: allowpaymentrequest || null,
+    importance: importance || null,
+    sandbox: (sandbox && [...sandbox].join(' ')) || null,
+    loading: loading || null,
+    styles: styles || null,
     name: name || null,
     className: className || null,
+    allowFullScreen: 'allowFullScreen' || null,
+    referrerpolicy: referrerpolicy || null,
+    title: title || null,
+    allow: allow || null,
     id: id || null,
-    onLoad: onLoad || null,
-    height: height || '100%',
+    'aria-labelledby': ariaLabelledby || null,
+    'aria-hidden': ariaHidden || null,
+    'aria-label': ariaLabel || null,
     width: width || '100%',
-    allow: 'autoplay',
+    height: height || '100%',
+    onLoad: onLoad || null,
+    onMouseOver: onMouseOver || null,
+    onMouseOut: onMouseOut || null,
+    key: key || 'iframe',
   })
   let props = Object.create(null)
   for (let prop of Object.keys(defaultProps)) {
@@ -53,6 +79,17 @@ const Iframe = ({
   for (let i of Object.keys(props.style)) {
     if (props.style[i] == null) {
       delete props.style[i]
+    }
+  }
+
+  if (props.styles) {
+    for (let key of Object.keys(props.styles)) {
+      if (props.styles.hasOwnProperty(key)) {
+        props.style[key] = props.styles[key]
+      }
+      if (Object.keys(props.styles).pop() == key) {
+        delete props.styles
+      }
     }
   }
 
@@ -71,23 +108,11 @@ const Iframe = ({
     }
   }
   return (
-    <React.Fragment>
-      {children ? (
-        <iframe
-          ref={iframeRef}
-          {...props}
-          style={{ colorScheme: 'normal', ...props.style }}
-        >
-          {children}
-        </iframe>
-      ) : (
-        <iframe
-          ref={iframeRef}
-          {...props}
-          style={{ colorScheme: 'normal', ...props.style }}
-        />
-      )}
-    </React.Fragment>
+    <iframe
+      {...props}
+      ref={iframeRef}
+      style={{ colorScheme: 'normal', ...props.style }}
+    />
   )
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -747,11 +747,11 @@ export interface Studio {
    */
 
   /**
-  * These are a new set of endpoints for managing guest codes and are different to the existing one
-  * To create a guest code, The guest code returned looks like this, linkUrl is what you should copy to the users 
-  */
+   * These are a new set of endpoints for managing guest codes and are different to the existing one
+   * To create a guest code, The guest code returned looks like this, linkUrl is what you should copy to the users
+   */
   createGuestLink: (baseUrl: string, options?: GuestOptions) => Promise<string>
- 
+
   /**
    * To delete a guest code
    */
@@ -760,8 +760,10 @@ export interface Studio {
   /**
    * To list all guest codes
    */
-  getGuestLinks: (options?: GuestOptions) => Promise<{ guestCodes: LiveApiModel.IssuedGuestCode[] }>
-  
+  getGuestLinks: (
+    options?: GuestOptions,
+  ) => Promise<{ guestCodes: LiveApiModel.IssuedGuestCode[] }>
+
   /**
    * Create a link with an embedded access token.
    * This link resolves to a URL demonstrating the stream output.
@@ -873,8 +875,23 @@ export type Props = { [prop: string]: any }
 
 export type LogLevel = 'Debug' | 'Info' | 'Warn' | 'Error'
 
+type SandboxAttributeValue =
+  | 'allow-downloads-without-user-activation'
+  | 'allow-forms'
+  | 'allow-modals'
+  | 'allow-orientation-lock'
+  | 'allow-pointer-lock'
+  | 'allow-popups'
+  | 'allow-popups-to-escape-sandbox'
+  | 'allow-presentation'
+  | 'allow-same-origin'
+  | 'allow-scripts'
+  | 'allow-storage-access-by-user-activation'
+  | 'allow-top-navigation'
+  | 'allow-top-navigation-by-user-activation'
+
 export interface IframeProps {
-  url?: string
+  url: string
   src?: string
   allowFullScreen?: boolean
   position?:
@@ -886,17 +903,38 @@ export interface IframeProps {
     | 'inherit'
     | 'initial'
     | 'unset'
-  display?: 'block' | 'none' | 'inline'
+  display?: 'block' | 'none' | 'inline' | 'initial'
   height?: string
   width?: string
-  overflow?: string
+  loading?: 'auto' | 'eager' | 'lazy'
   target?: string
+  importance?: 'auto' | 'high' | 'low'
+  overflow?: string
   styles?: object
   name?: string
+  allowpaymentrequest?: boolean
+  referrerpolicy?:
+    | 'no-referrer'
+    | 'no-referrer-when-downgrade'
+    | 'origin'
+    | 'origin-when-cross-origin'
+    | 'same-origin'
+    | 'strict-origin'
+    | 'strict-origin-when-cross-origin'
+    | 'unsafe-url'
   onLoad?: () => void
+  onMouseOver?: () => void
+  onMouseOut?: () => void
   frameBorder?: number
+  scrolling?: 'auto' | 'yes' | 'no'
   id?: string
+  ariaHidden?: boolean
+  ariaLabel?: string
+  ariaLabelledby?: string
+  sandbox?: SandboxAttributeValue | SandboxAttributeValue[]
+  allow?: string
   className?: string
-  children?: React.ReactNode
+  title?: string
+  key?: string
   iframeRef?: React.Ref<HTMLIFrameElement>
 }

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -1340,7 +1340,7 @@ export const commands = (_project: ScenelessProject) => {
           (x) => x?.props?.sourceProps?.type === 'image',
         )
 
-      // Delete all except image overlays
+      // Delete image overlays
       existingImageOverlays.forEach((x) => {
         CoreContext.Command.deleteNode({
           nodeId: x.id,

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -86,8 +86,8 @@ type GenerateGameSourceProps<T extends LiveApiModel.Source> = {
   address: T['address'] extends {
     dynamic: LiveApiModel.Source['address']['dynamic']
   }
-  ? { dynamic: { id: 'integration' } }
-  : never
+    ? { dynamic: { id: 'integration' } }
+    : never
   displayName?: string
   props?: any
 }
@@ -111,7 +111,7 @@ const ExternalSourceTypeMap = {
 
 export type ExternalSourceType = keyof typeof ExternalSourceTypeMap
 
-interface ScenelessProject extends SDK.Project { }
+interface ScenelessProject extends SDK.Project {}
 
 // Note: Assume project is a valid sceneless project
 // Note: In the future commands will be returned by an argument of SceneNode
@@ -289,7 +289,7 @@ export interface Commands {
   /**
    * remove video overlay from foreground layer
    */
-  removeCustomOverlay(): Promise<void>
+  removeCustomOverlay(id: string): Promise<void>
   /**
    * remove the active video overlay
    */
@@ -726,7 +726,7 @@ export const commands = (_project: ScenelessProject) => {
       ])
 
       await coreProject.compositor.reorder(foreground.id, baseForegroundLayers)
-    } catch (e) { }
+    } catch (e) {}
   }
 
   const commands: Commands = {
@@ -989,7 +989,7 @@ export const commands = (_project: ScenelessProject) => {
       })
     },
     async setActiveBanner(id: string) {
-      const [nodeTocheckForChildren, ...{ }] =
+      const [nodeTocheckForChildren, ...{}] =
         bannerContainer?.children || ([] as SceneNode[])
 
       /* Checking if the existingBannerNode has a property called chatOverlayId. If it does, it deletes the
@@ -1035,7 +1035,7 @@ export const commands = (_project: ScenelessProject) => {
     },
 
     async addChatOverlay(id: string, options: ChatOverlayProps) {
-      const [nodeTocheckForChildren, ...{ }] =
+      const [nodeTocheckForChildren, ...{}] =
         bannerContainer?.children || ([] as SceneNode[])
 
       /* Deleting the existing banner node if it exists. */
@@ -1329,14 +1329,24 @@ export const commands = (_project: ScenelessProject) => {
     },
 
     async addCustomOverlay(id: string, props: OverlayProps): Promise<void> {
-      const [existingForegroundNode, ...excessForegroundNode] =
-        foregroundImageIframeContainer?.children || ([] as SceneNode[])
-      // Delete all except one banner from the project
-      excessForegroundNode.forEach((x) => {
+      const existingForegroundNode =
+        foregroundImageIframeContainer?.children?.find(
+          (x) =>
+            x?.props?.sourceProps?.type === 'custom' && x?.props?.id === id,
+        )
+
+      const existingImageOverlays =
+        foregroundImageIframeContainer?.children?.filter(
+          (x) => x?.props?.sourceProps?.type === 'image',
+        )
+
+      // Delete all except image overlays
+      existingImageOverlays.forEach((x) => {
         CoreContext.Command.deleteNode({
           nodeId: x.id,
         })
       })
+
       const extendedDefaultStyles = {
         ...defaultStyles['custom'],
         ...(foregroundVideoContainer?.children.length && { opacity: 0 }),
@@ -1374,16 +1384,12 @@ export const commands = (_project: ScenelessProject) => {
       }
     },
 
-    async removeCustomOverlay(): Promise<void> {
-      // find overlay node by id
-      const [existingForegroundNode, ...excessForegroundNode] =
-        foregroundImageIframeContainer?.children || ([] as SceneNode[])
-      // if overlay exists, remove it
-      excessForegroundNode.forEach((x) => {
-        CoreContext.Command.deleteNode({
-          nodeId: x.id,
-        })
-      })
+    async removeCustomOverlay(id: string): Promise<void> {
+      const existingForegroundNode =
+        foregroundImageIframeContainer?.children?.find(
+          (x) =>
+            x?.props?.sourceProps?.type === 'custom' && x?.props?.id === id,
+        )
       if (existingForegroundNode) {
         if (existingForegroundNode?.props?.sourceProps?.type === 'custom') {
           await CoreContext.Command.deleteNode({
@@ -1413,7 +1419,6 @@ export const commands = (_project: ScenelessProject) => {
     },
 
     async removeVideoOverlay(): Promise<void> {
-      // find overlay node by id
       // find overlay node by id
       const [existingForegroundNode, ...excessForegroundNode] =
         foregroundVideoContainer?.children || ([] as SceneNode[])
@@ -2012,7 +2017,10 @@ export const commands = (_project: ScenelessProject) => {
           })
         })
     },
-    getParticipantNode(id: string, type: ParticipantType | ExternalSourceType = 'camera') {
+    getParticipantNode(
+      id: string,
+      type: ParticipantType | ExternalSourceType = 'camera',
+    ) {
       return content.children
         .concat(audioContainer.children)
         .find(
@@ -2166,7 +2174,7 @@ export const commands = (_project: ScenelessProject) => {
             // Get the source type as it corresponds to the track's type
             const sourceType =
               track.type === Track.Source.Camera ||
-                track.type === Track.Source.Microphone
+              track.type === Track.Source.Microphone
                 ? 'camera'
                 : 'screen'
 
@@ -2232,7 +2240,7 @@ export const commands = (_project: ScenelessProject) => {
       await Promise.all([
         ensureRootLayersProps(),
         ensureBackgroundChildLayersProps(),
-        ensureForegroundContainers()
+        ensureForegroundContainers(),
       ])
     } catch (error) {
       console.error('Error ensuring project validity:', error)


### PR DESCRIPTION
This update introduces support for enabling multiple custom overlays within the platform. Users can now activate more than one overlay simultaneously.

**Note:** This update currently targets custom overlays only. In the future, we plan to extend this functionality to include image overlays as well

https://xsolla.atlassian.net/browse/LSTREAM-796