### PR TITLE
feat: effects called multiple time when adding new element for first ime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.38",
+  "version": "3.0.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.38",
+      "version": "3.0.39",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.38",
+  "version": "3.0.39",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -94,14 +94,12 @@ const onDrop = async (
     })
   } else {
     // If the drop node is a transform, then swap
-    // is this even a valid case
     if (dragParent.id !== dropParent?.id) {
-      // return CoreContext.Command.swapNodes({
-      //   projectId: project.id,
-      //   nodeAId: dragNode.id,
-      //   nodeBId: dropNode.id,
-      // })
-      return
+      return CoreContext.Command.swapNodes({
+        projectId: project.id,
+        nodeAId: dragNode.id,
+        nodeBId: dropNode.id,
+      })
     }
   }
 
@@ -140,8 +138,7 @@ const ElementTree = (props: { nodeId: string }) => {
   } = useContext(CompositorContext)
   const { nodeId } = props
   const project = getProject(projectId)
-  const node = useMemo(() => project.compositor.get(nodeId), [nodeId])
-
+  const node = project.compositor.get(nodeId)
   const element = useMemo(() => CoreContext.compositor.getElement(node), [node])
   const [localState, setLocalState] = useState({})
   const nodeProps = {
@@ -327,12 +324,6 @@ const ElementTree = (props: { nodeId: string }) => {
     : {}
 
   useEffect(() => {
-    if (element) {
-      console.log('Element is changing', element.nodeId)
-    }
-  }, [transformRef.current, element])
-
-  useEffect(() => {
     if (transformRef.current && element) {
       transformRef.current.appendChild(element.root)
       Object.assign(transformRef.current.style, {
@@ -473,8 +464,8 @@ const ElementTree = (props: { nodeId: string }) => {
         className="interactive-overlay"
         ref={interactiveRef}
         style={{
-          width: (node.props?.isAudioOnly ?? false) ? '0%' : '100%',
-          height: (node.props?.isAudioOnly ?? false) ? '0%' : '100%',
+          width: node.props?.isAudioOnly ?? false ? '0%' : '100%',
+          height: node.props?.isAudioOnly ?? false ? '0%' : '100%',
           position: 'absolute',
           zIndex: 2,
         }}

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -140,9 +140,9 @@ const ElementTree = (props: { nodeId: string }) => {
   } = useContext(CompositorContext)
   const { nodeId } = props
   const project = getProject(projectId)
-  const node = project.compositor.get(nodeId)
+  const node = useMemo(() => project.compositor.get(nodeId), [nodeId])
 
-  const element = CoreContext.compositor.getElement(node)
+  const element = useMemo(() => CoreContext.compositor.getElement(node), [node])
   const [localState, setLocalState] = useState({})
   const nodeProps = {
     ...node.props,
@@ -327,6 +327,12 @@ const ElementTree = (props: { nodeId: string }) => {
     : {}
 
   useEffect(() => {
+    if (element) {
+      console.log('Element is changing', element.nodeId)
+    }
+  }, [transformRef.current, element])
+
+  useEffect(() => {
     if (transformRef.current && element) {
       transformRef.current.appendChild(element.root)
       Object.assign(transformRef.current.style, {
@@ -343,7 +349,7 @@ const ElementTree = (props: { nodeId: string }) => {
         ...(nodeProps.style || {}),
       })
     }
-  }, [transformRef.current, element])
+  }, [element])
 
   useEffect(() => {
     const onDoubleClick = isDragTarget
@@ -361,13 +367,13 @@ const ElementTree = (props: { nodeId: string }) => {
     return () => {
       interactiveRef.current?.removeEventListener('dblclick', onDoubleClick)
     }
-  }, [interactiveRef.current])
+  }, [])
 
   useEffect(() => {
     if (rootRef.current) {
       Object.assign(interactiveRef.current, layoutDragHandlers)
     }
-  }, [rootRef.current])
+  }, [])
 
   const layoutProps = {
     layout,

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -139,7 +139,7 @@ const ElementTree = (props: { nodeId: string }) => {
   const { nodeId } = props
   const project = getProject(projectId)
   const node = project.compositor.get(nodeId)
-  const element = useMemo(() => CoreContext.compositor.getElement(node), [node])
+  const element = CoreContext.compositor.getElement(node)
   const [localState, setLocalState] = useState({})
   const nodeProps = {
     ...node.props,
@@ -340,7 +340,7 @@ const ElementTree = (props: { nodeId: string }) => {
         ...(nodeProps.style || {}),
       })
     }
-  }, [element])
+  }, [])
 
   useEffect(() => {
     const onDoubleClick = isDragTarget

--- a/src/helpers/database.ts
+++ b/src/helpers/database.ts
@@ -8,7 +8,10 @@ export const ForegroundLayers = [
   {
     name: 'ImageIframeOverlayContainer',
     id: 'fg-image-iframe',
-    layout: 'Free',
+    layout: 'Layered',
+    layoutProps: {
+      type: 'image-iframe-overlay',
+    },
   },
   {
     name: 'BannerContainer',

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -641,7 +641,10 @@ export const commands = (_project: ScenelessProject) => {
           {
             name: 'ImageIframeOverlay',
             id: 'fg-image-iframe',
-            layout: 'Free',
+            layout: 'Layered',
+            layoutProps: {
+              type: 'image-iframe-overlay',
+            },
           },
           foreground.id,
         )
@@ -651,6 +654,15 @@ export const commands = (_project: ScenelessProject) => {
         )
         return nodeId
       } else {
+        // ensure the image iframe container is of type Layered
+        if(foregroundImageIframeContainer.props.layout !== 'Layered') {
+          await coreProject.compositor.update(foregroundImageIframeContainer.id, {
+            layout: 'Layered',
+            layoutProps: {
+              type: 'image-iframe-overlay',
+            },
+          })
+        }
         return foregroundImageIframeContainer.id
       }
     }
@@ -2262,9 +2274,11 @@ export type LayoutProps = {
   useGrid?: boolean
   reverse?: boolean
   /** used for type alert */
-  type?: string
+  type?: 'alert' | 'image-iframe-overlay'
   /** Either 'top-center' or 'bottom-center' **/
   preset?: string
+  /** used for type image-iframe-overlay to order the layers */
+  order?: string[]
 }
 
 type ScenelessSettings = {


### PR DESCRIPTION
When a new node is added to the canvas, the useEffect hook for the previous node is triggered twice—once for the previous node and once for the new node. This causes the previous node to be removed and then re-added to the canvas, creating a flickering effect.

Previously, this issue didn’t occur because the canvas only supported a single child node at any given time. However, with the recent requirement to support multiple overlays within the same container, this behavior has surfaced as a problem.

From a technical perspective, I believe adding refs to the dependency array of the useEffect is unnecessary since refs are generally stable across React render cycles.


https://github.com/user-attachments/assets/a40f2857-f1fc-4d0c-8b35-772252897dfb


https://xsolla.atlassian.net/browse/LSTREAM-811