### PR TITLE
fix: gamesource gap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.42",
+  "version": "3.0.43",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -158,169 +158,169 @@ const ElementTree = (props: { nodeId: string }) => {
   let layoutDragHandlers =
     isDropTarget && draggingNodeId && !isDraggingSelf.current
       ? ({
-          onpointerup: (e) => {
-            log.debug('Compositor: PointerUp "Layout"', node.id)
-            return onDrop(
-              {
-                dropType: 'layout',
-                dropNodeId: node.id,
-                dragNodeId: draggingNodeId,
-                project,
-              },
-              e,
-            )
-          },
-          onpointerenter: (e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            rootRef.current?.toggleAttribute(
-              'data-layout-drop-target-active',
-              true,
-            )
-          },
-          onpointerleave: (e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            rootRef.current?.toggleAttribute(
-              'data-layout-drop-target-active',
-              false,
-            )
-          },
-        } as Partial<HTMLElement>)
-      : {}
-
-  let transformDragHandlers = isDragTarget
-    ? ({
-        onpointerdown: (e) => {
-          // Check for pointer distance move > 1px before treating as a drag
-          activePointerCoords.current = { x: e.clientX, y: e.clientY }
-          let latestPointerCoords = activePointerCoords.current
-
-          log.debug('Compositor: Dragging', node.id)
-          wrapperEl.toggleAttribute('data-dragging', true)
-          rootRef.current?.toggleAttribute('data-drag-target-active', true)
-
-          const adjustPreviewPosition = () => {
-            if (!isDraggingSelf.current) return
-
-            // Runs every frame while dragging
-            dragPreviewEl.style.top = latestPointerCoords.y - 20 + 'px'
-            dragPreviewEl.style.left = latestPointerCoords.x - 20 + 'px'
-            dragPreviewEl.toggleAttribute('data-active', true)
-
-            requestAnimationFrame(() => adjustPreviewPosition())
-          }
-
-          const onGlobalPointerMove = (e: PointerEvent) => {
-            if (
-              !isDraggingSelf.current &&
-              Boolean(activePointerCoords.current)
-            ) {
-              const isDragging = Boolean(
-                Math.abs(e.clientX - activePointerCoords.current.x) >=
-                  DRAG_DISTANCE_BUFFER ||
-                  Math.abs(e.clientY - activePointerCoords.current.y) >=
-                    DRAG_DISTANCE_BUFFER,
-              )
-
-              // Runs only once when dragging starts
-              if (isDragging) {
-                setDraggingNodeId(node.id)
-                isDraggingSelf.current = isDragging
-                adjustPreviewPosition()
-              }
-            }
-            latestPointerCoords = { x: e.clientX, y: e.clientY }
-          }
-
-          onGlobalPointerMove(e)
-
-          const onGlobalPointerUp = (e: PointerEvent) => {
-            setTimeout(() => {
-              log.debug('Compositor: DragEnd', e)
-              activePointerCoords.current = undefined
-              isDraggingSelf.current = false
-              setDraggingNodeId(null)
-
-              dragPreviewEl.toggleAttribute('data-active', false)
-              wrapperEl.toggleAttribute('data-dragging', false)
-              wrapperEl.toggleAttribute('data-drop-target-ready', false)
-              wrapperEl.querySelectorAll('[data-item]').forEach((x) => {
-                x.toggleAttribute('data-drag-target-active', false)
-                x.toggleAttribute('data-layout-drop-target-active', false)
-                x.toggleAttribute('data-transform-drop-target-active', false)
-                x.toggleAttribute('data-transform-drop-self-active', false)
-              })
-            })
-
-            document.removeEventListener('pointermove', onGlobalPointerMove)
-            document.removeEventListener('pointerup', onGlobalPointerUp)
-          }
-
-          document.addEventListener('pointermove', onGlobalPointerMove)
-          document.addEventListener('pointerup', onGlobalPointerUp)
-        },
         onpointerup: (e) => {
-          // If a target is draggable, it will also be treated as
-          //  a drop target (swap element positions)
-          log.debug('Compositor: PointerUp "Node"', node.id)
-          if (draggingNodeIdRef && draggingNodeIdRef !== node.id) {
-            onDrop(
-              {
-                dropType: 'transform',
-                dropNodeId: node.id,
-                dragNodeId: draggingNodeIdRef,
-                project,
-              },
-              e,
-            )
-          }
+          log.debug('Compositor: PointerUp "Layout"', node.id)
+          return onDrop(
+            {
+              dropType: 'layout',
+              dropNodeId: node.id,
+              dragNodeId: draggingNodeId,
+              project,
+            },
+            e,
+          )
         },
         onpointerenter: (e) => {
           e.preventDefault()
           e.stopPropagation()
-
-          if (!draggingNodeIdRef) return
-
-          if (isDraggingSelf.current) {
-            log.debug('Compositor: Mouseenter self', node.id)
-            rootRef.current?.toggleAttribute(
-              'data-transform-drop-self-active',
-              true,
-            )
-          } else {
-            log.debug('Compositor: Mouseenter other', node.id)
-            rootRef.current?.toggleAttribute(
-              'data-transform-drop-target-active',
-              true,
-            )
-
-            // Timeout to ensure "dragenter" runs after
-            //  "dragleave" for other elements for global updates
-            setTimeout(() => {
-              if (!isDraggingSelf.current) {
-                wrapperEl.toggleAttribute('data-drop-target-ready', true)
-              }
-            })
-          }
+          rootRef.current?.toggleAttribute(
+            'data-layout-drop-target-active',
+            true,
+          )
         },
         onpointerleave: (e) => {
           e.preventDefault()
           e.stopPropagation()
-
-          if (!draggingNodeIdRef) return
-
           rootRef.current?.toggleAttribute(
-            'data-transform-drop-self-active',
+            'data-layout-drop-target-active',
             false,
           )
-          rootRef.current?.toggleAttribute(
-            'data-transform-drop-target-active',
-            false,
-          )
-          wrapperEl.toggleAttribute('data-drop-target-ready', false)
         },
       } as Partial<HTMLElement>)
+      : {}
+
+  let transformDragHandlers = isDragTarget
+    ? ({
+      onpointerdown: (e) => {
+        // Check for pointer distance move > 1px before treating as a drag
+        activePointerCoords.current = { x: e.clientX, y: e.clientY }
+        let latestPointerCoords = activePointerCoords.current
+
+        log.debug('Compositor: Dragging', node.id)
+        wrapperEl.toggleAttribute('data-dragging', true)
+        rootRef.current?.toggleAttribute('data-drag-target-active', true)
+
+        const adjustPreviewPosition = () => {
+          if (!isDraggingSelf.current) return
+
+          // Runs every frame while dragging
+          dragPreviewEl.style.top = latestPointerCoords.y - 20 + 'px'
+          dragPreviewEl.style.left = latestPointerCoords.x - 20 + 'px'
+          dragPreviewEl.toggleAttribute('data-active', true)
+
+          requestAnimationFrame(() => adjustPreviewPosition())
+        }
+
+        const onGlobalPointerMove = (e: PointerEvent) => {
+          if (
+            !isDraggingSelf.current &&
+            Boolean(activePointerCoords.current)
+          ) {
+            const isDragging = Boolean(
+              Math.abs(e.clientX - activePointerCoords.current.x) >=
+              DRAG_DISTANCE_BUFFER ||
+              Math.abs(e.clientY - activePointerCoords.current.y) >=
+              DRAG_DISTANCE_BUFFER,
+            )
+
+            // Runs only once when dragging starts
+            if (isDragging) {
+              setDraggingNodeId(node.id)
+              isDraggingSelf.current = isDragging
+              adjustPreviewPosition()
+            }
+          }
+          latestPointerCoords = { x: e.clientX, y: e.clientY }
+        }
+
+        onGlobalPointerMove(e)
+
+        const onGlobalPointerUp = (e: PointerEvent) => {
+          setTimeout(() => {
+            log.debug('Compositor: DragEnd', e)
+            activePointerCoords.current = undefined
+            isDraggingSelf.current = false
+            setDraggingNodeId(null)
+
+            dragPreviewEl.toggleAttribute('data-active', false)
+            wrapperEl.toggleAttribute('data-dragging', false)
+            wrapperEl.toggleAttribute('data-drop-target-ready', false)
+            wrapperEl.querySelectorAll('[data-item]').forEach((x) => {
+              x.toggleAttribute('data-drag-target-active', false)
+              x.toggleAttribute('data-layout-drop-target-active', false)
+              x.toggleAttribute('data-transform-drop-target-active', false)
+              x.toggleAttribute('data-transform-drop-self-active', false)
+            })
+          })
+
+          document.removeEventListener('pointermove', onGlobalPointerMove)
+          document.removeEventListener('pointerup', onGlobalPointerUp)
+        }
+
+        document.addEventListener('pointermove', onGlobalPointerMove)
+        document.addEventListener('pointerup', onGlobalPointerUp)
+      },
+      onpointerup: (e) => {
+        // If a target is draggable, it will also be treated as
+        //  a drop target (swap element positions)
+        log.debug('Compositor: PointerUp "Node"', node.id)
+        if (draggingNodeIdRef && draggingNodeIdRef !== node.id) {
+          onDrop(
+            {
+              dropType: 'transform',
+              dropNodeId: node.id,
+              dragNodeId: draggingNodeIdRef,
+              project,
+            },
+            e,
+          )
+        }
+      },
+      onpointerenter: (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        if (!draggingNodeIdRef) return
+
+        if (isDraggingSelf.current) {
+          log.debug('Compositor: Mouseenter self', node.id)
+          rootRef.current?.toggleAttribute(
+            'data-transform-drop-self-active',
+            true,
+          )
+        } else {
+          log.debug('Compositor: Mouseenter other', node.id)
+          rootRef.current?.toggleAttribute(
+            'data-transform-drop-target-active',
+            true,
+          )
+
+          // Timeout to ensure "dragenter" runs after
+          //  "dragleave" for other elements for global updates
+          setTimeout(() => {
+            if (!isDraggingSelf.current) {
+              wrapperEl.toggleAttribute('data-drop-target-ready', true)
+            }
+          })
+        }
+      },
+      onpointerleave: (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        if (!draggingNodeIdRef) return
+
+        rootRef.current?.toggleAttribute(
+          'data-transform-drop-self-active',
+          false,
+        )
+        rootRef.current?.toggleAttribute(
+          'data-transform-drop-target-active',
+          false,
+        )
+        wrapperEl.toggleAttribute('data-drop-target-ready', false)
+      },
+    } as Partial<HTMLElement>)
     : {}
 
   useEffect(() => {
@@ -345,7 +345,7 @@ const ElementTree = (props: { nodeId: string }) => {
   useEffect(() => {
     const onDoubleClick = isDragTarget
       ? () => onElementDoubleClick?.(node)
-      : () => {}
+      : () => { }
 
     if (interactiveRef.current) {
       Object.assign(interactiveRef.current, transformDragHandlers)
@@ -639,20 +639,25 @@ export const render = (settings: CompositorSettings) => {
   const { x: rootWidth, y: rootHeight } = root.props.size
 
   const setScale = () => {
-    const { width, height } = containerEl.getBoundingClientRect();
-    // Calculate available space considering padding
-    const availableWidth = width - (PADDING * 2);
-    const availableHeight = height - (PADDING * 2);
-    
-    // Calculate scales for both dimensions
-    const widthScale = availableWidth / rootWidth;
-    const heightScale = availableHeight / rootHeight;
-    
-    // Use the smaller scale to ensure content fits
-    const scale = Math.min(widthScale, heightScale);
-    
-    // Apply transform with hardware acceleration
-    wrapperEl.style.transform = `scale(${scale}) translateZ(0)`;
+    let { width, height } = containerEl.getBoundingClientRect()
+    const containerRatio = width / height
+    const compositorRatio = rootWidth / rootHeight
+
+    let scale
+    if (width && height) {
+      if (compositorRatio > containerRatio) {
+        // If compositor ratio is higher, width is the constraint
+        scale = width / (rootWidth + PADDING * 2)
+      } else {
+        // If container ratio is higher, height is the constraint
+        scale = height / (rootHeight + PADDING * 2)
+      }
+    } else {
+      // It's possible the container will have no size defined (width/height=0)
+      scale = 1
+    }
+
+    wrapperEl.style.transform = `scale(${scale}) translateZ(0)`
     // @ts-ignore
     window.__scale = scale
     render()
@@ -995,13 +1000,12 @@ const themes = {
         transform: translateX(-100%);
         opacity: 0 !important;
         white-space: nowrap;
-        ${
-          showNameBanners &&
-          `
+        ${showNameBanners &&
+      `
           opacity: 1 !important;
           transform: translateX(0);
         `
-        }
+      }
       }
 
       .NameBanner[data-size="4"] {
@@ -1086,8 +1090,8 @@ const themes = {
 
     .Banner, .NameBanner, .ChatOverlay {
         background: ${color(primaryColor)
-          .fade(color(primaryColor).alpha() * 0.7)
-          .toString()} !important;
+        .fade(color(primaryColor).alpha() * 0.7)
+        .toString()} !important;
         padding: ${scale(40)} ${scale(40)} ${scale(40)} ${scale(60)} !important;
         position: relative !important;
         margin-bottom: ${scale(40)} !important;
@@ -1140,37 +1144,36 @@ const themes = {
         transform: translateX(-100%);
         opacity: 0 !important;
         white-space: nowrap;
-        ${
-          showNameBanners &&
-          `
+        ${showNameBanners &&
+      `
           opacity: 1 !important;
           transform: translateX(0);
         `
-        }
+      }
       }
 
       .NameBanner[data-size="4"] {
         padding: ${scale(40)} ${scale(40)} ${scale(40)} ${scale(
-          40 + 20,
-        )} !important;
+        40 + 20,
+      )} !important;
         font-size: ${scale(34)} !important;
       }
       .NameBanner[data-size="3"] {
         padding: ${scale(16)} ${scale(40)} ${scale(16)} ${scale(
-          40 + 20,
-        )} !important;
+        40 + 20,
+      )} !important;
         font-size: ${scale(34)} !important;
       }
       .NameBanner[data-size="2"] {
         padding: ${scale(12)} ${scale(24)} ${scale(12)} ${scale(
-          24 + 20,
-        )} !important;
+        24 + 20,
+      )} !important;
         font-size: ${scale(24)} !important;
       }
       .NameBanner[data-size="1"], .NameBanner[data-size="0"] {
         padding: ${scale(12)} ${scale(16)} ${scale(12)} ${scale(
-          16 + 20,
-        )} !important;
+        16 + 20,
+      )} !important;
         font-size: ${scale(18)} !important;
       }
       .NameBanner[data-size="0"] {
@@ -1270,13 +1273,12 @@ const themes = {
         transform: translateX(-100%);
         opacity: 0 !important;
         white-space: nowrap;
-        ${
-          showNameBanners &&
-          `
+        ${showNameBanners &&
+      `
           opacity: 1 !important;
           transform: translateX(0);
         `
-        }
+      }
       }
 
       ls-layout[layout="Presentation"][props*="\\"cover\\"\\:true"] > :first-child .NameBanner {

--- a/src/helpers/compositor.tsx
+++ b/src/helpers/compositor.tsx
@@ -639,26 +639,20 @@ export const render = (settings: CompositorSettings) => {
   const { x: rootWidth, y: rootHeight } = root.props.size
 
   const setScale = () => {
-    let { width, height } = containerEl.getBoundingClientRect()
-    const containerRatio = width / height
-    const compositorRatio = rootWidth / rootHeight
-
-    let scale
-    if (width && height) {
-      if (compositorRatio > containerRatio) {
-        // If compositor ratio is higher, width is the constraint
-        scale = width / (rootWidth + PADDING * 2)
-      } else {
-        // If container ratio is higher, height is the constraint
-        scale = height / (rootHeight + PADDING * 2)
-      }
-    } else {
-      // It's possible the container will have no size defined (width/height=0)
-      scale = 1
-    }
-
-    wrapperEl.style.willChange = `transform`
-    wrapperEl.style.transform = `scale(${scale}) translateZ(0)`
+    const { width, height } = containerEl.getBoundingClientRect();
+    // Calculate available space considering padding
+    const availableWidth = width - (PADDING * 2);
+    const availableHeight = height - (PADDING * 2);
+    
+    // Calculate scales for both dimensions
+    const widthScale = availableWidth / rootWidth;
+    const heightScale = availableHeight / rootHeight;
+    
+    // Use the smaller scale to ensure content fits
+    const scale = Math.min(widthScale, heightScale);
+    
+    // Apply transform with hardware acceleration
+    wrapperEl.style.transform = `scale(${scale}) translateZ(0)`;
     // @ts-ignore
     window.__scale = scale
     render()

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -590,6 +590,16 @@ export const commands = (_project: ScenelessProject) => {
     (x) => x.props.id === 'fg-banners',
   )
 
+  const ensureRootLayersReorder = async () => {
+    if (!background || !content || !foreground || !audioContainer) return
+    await coreProject.compositor.reorder(root.id, [
+      background.id,
+      content.id,
+      foreground.id,
+      audioContainer.id,
+    ])
+  }
+
   const ensureRootLayersProps = async () => {
     if (background?.props?.layout !== 'Layered') {
       await coreProject.compositor.update(background.id, {
@@ -2250,6 +2260,7 @@ export const commands = (_project: ScenelessProject) => {
   const ensureValid = async () => {
     try {
       await Promise.all([
+        ensureRootLayersReorder(),
         ensureRootLayersProps(),
         ensureBackgroundChildLayersProps(),
         ensureForegroundContainers(),
@@ -2339,23 +2350,6 @@ export const createCompositor = async (
   const baseLayers = await Promise.all([
     project.insert(
       {
-        id: 'audio',
-        name: 'AudioContainer',
-        layout: 'Free',
-        size: {
-          x: 0,
-          y: 0,
-        },
-        position: {
-          x: 0,
-          y: 0,
-        },
-        opacity: 0,
-      },
-      root.id,
-    ),
-    project.insert(
-      {
         name: 'Background',
         id: 'bg',
         layout: 'Layered',
@@ -2377,6 +2371,23 @@ export const createCompositor = async (
         id: 'foreground',
         name: 'Overlays',
         layout: 'Layered',
+      },
+      root.id,
+    ),
+    project.insert(
+      {
+        id: 'audio',
+        name: 'AudioContainer',
+        layout: 'Free',
+        size: {
+          x: 0,
+          y: 0,
+        },
+        position: {
+          x: 0,
+          y: 0,
+        },
+        opacity: 0,
       },
       root.id,
     ),

--- a/src/helpers/sceneless-project.ts
+++ b/src/helpers/sceneless-project.ts
@@ -589,17 +589,6 @@ export const commands = (_project: ScenelessProject) => {
   let bannerContainer = foreground?.children?.find(
     (x) => x.props.id === 'fg-banners',
   )
-
-  const ensureRootLayersReorder = async () => {
-    if (!background || !content || !foreground || !audioContainer) return
-    await coreProject.compositor.reorder(root.id, [
-      background.id,
-      content.id,
-      foreground.id,
-      audioContainer.id,
-    ])
-  }
-
   const ensureRootLayersProps = async () => {
     if (background?.props?.layout !== 'Layered') {
       await coreProject.compositor.update(background.id, {
@@ -2260,7 +2249,6 @@ export const commands = (_project: ScenelessProject) => {
   const ensureValid = async () => {
     try {
       await Promise.all([
-        ensureRootLayersReorder(),
         ensureRootLayersProps(),
         ensureBackgroundChildLayersProps(),
         ensureForegroundContainers(),
@@ -2350,6 +2338,23 @@ export const createCompositor = async (
   const baseLayers = await Promise.all([
     project.insert(
       {
+        id: 'audio',
+        name: 'AudioContainer',
+        layout: 'Free',
+        size: {
+          x: 0,
+          y: 0,
+        },
+        position: {
+          x: 0,
+          y: 0,
+        },
+        opacity: 0,
+      },
+      root.id,
+    ),
+    project.insert(
+      {
         name: 'Background',
         id: 'bg',
         layout: 'Layered',
@@ -2371,23 +2376,6 @@ export const createCompositor = async (
         id: 'foreground',
         name: 'Overlays',
         layout: 'Layered',
-      },
-      root.id,
-    ),
-    project.insert(
-      {
-        id: 'audio',
-        name: 'AudioContainer',
-        layout: 'Free',
-        size: {
-          x: 0,
-          y: 0,
-        },
-        position: {
-          x: 0,
-          y: 0,
-        },
-        opacity: 0,
       },
       root.id,
     ),


### PR DESCRIPTION
This PR addresses two issues observed in OpenTail related to the GameSource component:

**Flickering When Adding a New Participant**
- 	The flickering occurred because the layout calculation for GameSource sets the inset property to auto during load time.
- 	When inset is auto, it positions the element dynamically based on its containing block. This behavior causes reflows and repaints during layout updates, leading to flickering.
- 	Fix: Updated the logic to use fixed px values for inset instead of relying on auto. This ensures stable positioning and avoids recalculation during reflows.

**Gaps Around the GameSource Component**

- 	The gaps were a side effect of the pre-optimization attempt using the will-change property.
- 	According to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change), the will-change property should be used cautiously and only when absolutely necessary. Overuse can degrade performance rather than improve it.
- 	Fix: Removed the unnecessary will-change property to prevent the gaps and improve layout stability.

https://xsolla.atlassian.net/browse/LSTREAM-892
https://xsolla.atlassian.net/browse/LSTREAM-893