### PR TITLE
chore: Add Option to Update Layout Only for Resolution Change in Studio Load Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log.txt
 docs/
 .npmrc
 renderer/renderer.json
+.aider*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.42",
+  "version": "3.0.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.42",
+      "version": "3.0.46",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.45",
+  "version": "3.0.46",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/data.ts
+++ b/src/core/data.ts
@@ -117,6 +117,7 @@ export const hydrateProject = async (
     x: number
     y: number
   },
+  updateLayoutOnly?: boolean,
 ) => {
   const metadata = project.metadata || {}
 
@@ -140,7 +141,7 @@ export const hydrateProject = async (
   }
 
   // handle composition size changing
-  if (size) {
+  if (size && !updateLayoutOnly) {
     updateRequest.rendering = {
       video: {
         width: size.x,
@@ -148,9 +149,9 @@ export const hydrateProject = async (
         framerate: 30,
       },      
     };
-
     updateRequest.updateMask.push('rendering');
   }
+
 
   if (updateRequest.updateMask.length) {
     await CoreContext.clients.LiveApi().project.updateProject(updateRequest);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -602,6 +602,9 @@ const load = async (
     x: number
     y: number
   },
+  options?: {
+    updateLayoutOnly?: boolean
+  }
 ): Promise<SDK.User> => {
   let user = getBaseUser()
   if (user) {
@@ -621,7 +624,7 @@ const load = async (
   await client.load(accessToken)
 
   // Load the projects and user data
-  const result = await CoreContext.Request.loadUser(size)
+  const result = await CoreContext.Request.loadUser(size, options)
 
   // TODO: Move to UserLoaded event handler
   setAppState({

--- a/src/core/requests.ts
+++ b/src/core/requests.ts
@@ -106,10 +106,15 @@ export const deleteProject = async (request: { projectId: string }) => {
  * Load the user data from whatever access token has been registered
  *  with the API.
  */
-export const loadUser = async (size?: {
-  x: number
-  y: number
-}): Promise<{
+export const loadUser = async (
+  size?: {
+    x: number
+    y: number
+  },
+  options?: {
+    updateLayoutOnly?: boolean
+  }
+): Promise<{
   user: InternalUser
   projects: InternalProject[]
   sources: InternalSource[]
@@ -146,7 +151,7 @@ export const loadUser = async (size?: {
   const projects = await Promise.all(
     collection.projects
       .filter((p) => Boolean(p.metadata?.layoutId))
-      .map((project) => hydrateProject(project, 'ROLE_HOST' as Role, size)),
+      .map((project) => hydrateProject(project, 'ROLE_HOST' as Role, size, options?.updateLayoutOnly)),
   )
 
   return {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -782,7 +782,7 @@ export interface Studio {
    * ----
    * **Emits {@link UserLoaded}**
    */
-  load: (accessToken: string, size?: { x: number; y: number }) => Promise<User>
+  load: (accessToken: string, size?: { x: number; y: number }, options?: { updateLayoutOnly?: boolean }) => Promise<User>
   /**
    * Renders a project into the supplied HTML Element.
    */


### PR DESCRIPTION
Added a new option/flag to the studio.load function to conditionally trigger layout updates. 

The video rendering resolution and canvas resolution are two distinct things. For canvas resolution, we strictly support 720p and 1080p, depending on the user’s plan. However, the video rendering resolution can go as low as 480p if required.

When the user modifies the video rendering resolution and reloads the project, the initial `studio.load` resets the video rendering resolution to match the canvas resolution. This reset is based on the user’s plan, which determines whether the canvas resolution is set to 720p or 1080p.

https://xsolla.atlassian.net/browse/LSTREAM-805