### PR TITLE
feat: add autoplay attribute to Alert and Overlay components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api.stream/studio-kit",
-      "version": "3.0.46",
+      "version": "3.0.47",
       "license": "MIT",
       "dependencies": {
         "@api.stream/livekit-server-sdk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.stream/studio-kit",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "description": "Client SDK for building studio experiences with API.stream",
   "license": "MIT",
   "private": false,

--- a/src/core/transforms/Alert.tsx
+++ b/src/core/transforms/Alert.tsx
@@ -71,6 +71,7 @@ export const Alert = {
                             width={width}
                             onLoad={resizeIframe}
                             styles={{ ...meta?.style }}
+                            allow="autoplay"
                         />
                     </div>
                 </APIKitAnimation>

--- a/src/core/transforms/Overlay.tsx
+++ b/src/core/transforms/Overlay.tsx
@@ -97,6 +97,7 @@ export const Overlay = {
               width={width}
               onLoad={resizeIframe}
               styles={{ ...meta?.style }}
+              allow='autoplay'
             />
           </React.Fragment>
         )


### PR DESCRIPTION
Add 'allow' attribute to iframe to enable audio autoplay

It appears that Chrome or an iframe policy update now requires this attribute for autoplay. Previously, it wasn't needed,
but adding it now ensures audio will play as expected.

https://xsolla.atlassian.net/browse/LSTREAM-963